### PR TITLE
Made AWS accessKeyId and secretAccessKey optional for SNS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Create an IAM user with permissions to SNS and SQS and copy the access key and s
   "provider": "fs",
   "sync": {
     "name": "aws-sns",
+    // the rest is optional
     "accessKeyId": "...",
     "secretAccessKey": "..."
-    // the rest is optional
     "topic": "jsreport",
     "subscription": "<host id>",
     "region": "us-east-1"

--- a/lib/syncAWS.js
+++ b/lib/syncAWS.js
@@ -8,15 +8,15 @@ const { serialize, parse } = require('jsreport-fs-store/lib/customUtils')
 const subscriptionName = 'jsreport-' + crypto.createHash('sha1').update(hostname + __dirname).digest('hex')
 
 module.exports = ({ topic = 'jsreport', accessKeyId, secretAccessKey, subscription = subscriptionName, region = 'us-east-1', logger }) => {
-  if (!accessKeyId) {
-    throw new Error('The fs store is configured to use aws sns sync but the accessKeyId is not set. Use store.sync.accessKeyId or extensions.fs-store-aws-sns-sync.accessKeyId to set the proper value.')
+  let sns
+  let sqs
+  if (accessKeyId != null && secretAccessKey != null) {
+      sns = new SNS({ accessKeyId, secretAccessKey, region })
+      sqs = new SQS({ accessKeyId, secretAccessKey, region })
+  } else {
+      sns = new SNS({ region })
+      sqs = new SQS({ region })
   }
-  if (!secretAccessKey) {
-    throw new Error('The fs store is configured to use aws sns sync but the accousecretAccessKeyntKey is not set. Use store.sync.secretAccessKey or extensions.fs-store-aws-sns-sync.secretAccessKey to set the proper value.')
-  }
-
-  const sns = new SNS({ accessKeyId, secretAccessKey, region })
-  const sqs = new SQS({ accessKeyId, secretAccessKey, region })
   Promise.promisifyAll(sns)
   Promise.promisifyAll(sqs)
   let topicArn

--- a/lib/syncAWS.js
+++ b/lib/syncAWS.js
@@ -11,11 +11,11 @@ module.exports = ({ topic = 'jsreport', accessKeyId, secretAccessKey, subscripti
   let sns
   let sqs
   if (accessKeyId != null && secretAccessKey != null) {
-      sns = new SNS({ accessKeyId, secretAccessKey, region })
-      sqs = new SQS({ accessKeyId, secretAccessKey, region })
+    sns = new SNS({ accessKeyId, secretAccessKey, region })
+    sqs = new SQS({ accessKeyId, secretAccessKey, region })
   } else {
-      sns = new SNS({ region })
-      sqs = new SQS({ region })
+    sns = new SNS({ region })
+    sqs = new SQS({ region })
   }
   Promise.promisifyAll(sns)
   Promise.promisifyAll(sqs)


### PR DESCRIPTION
Hi, we use AWS IAM roles as credentials that don't require to use **accessKeyId** and **secretAccessKey** for SNS (and others AWS services), but currently there is an exception if the credentials are not provided, because of this checks:
```javascript
if (!accessKeyId) {
    throw new Error('The fs store is configured to use aws sns sync but the accessKeyId is not set. Use store.sync.accessKeyId or extensions.fs-store-aws-sns-sync.accessKeyId to set the proper value.')
  }
  if (!secretAccessKey) {
    throw new Error('The fs store is configured to use aws sns sync but the accousecretAccessKeyntKey is not set. Use store.sync.secretAccessKey or extensions.fs-store-aws-sns-sync.secretAccessKey to set the proper value.')
  }
```
 It would be nice to make the credentials **accessKeyId** and **secretAccessKey** optional.